### PR TITLE
Keep from tangling with guard 2.0

### DIFF
--- a/guard-prove.gemspec
+++ b/guard-prove.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = '>= 1.3.6'
   s.rubyforge_project         = 'guard-prove'
   
-  s.add_dependency 'guard', '>= 1.1.1'
+  s.add_dependency 'guard', '~> 1'
   s.add_dependency 'systemu', '>= 1.2.0'
   
   s.add_development_dependency 'bundler', '~> 1.0.7'


### PR DESCRIPTION
Version dependency spec was allowing guard 2.0 to be installed with guard-prove to great misery